### PR TITLE
Insert form

### DIFF
--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -22,13 +22,24 @@
    [playground.server]
    [playground.service]))
 
+;; ugly hack, will disappear when we use the newer project template
+(def vemv? (-> (System/getenv "USER") #{"vemv"}))
+
 (defn dev-system
   []
   (component/system-map
    :service-map playground.server/dev-map
    ;; :background-processor (background-processor/new :queue-name "cljtest")
    ;; :enqueuer (enqueuer/new :queue-name "cljtest")
-   :db (modular.postgres/map->Postgres {:url "jdbc:postgresql:postgres" :user "postgres" :password "postgres"})
+   :db (modular.postgres/map->Postgres {:url (if vemv?
+                                               "jdbc:postgresql:ebdb"
+                                               "jdbc:postgresql:postgres")
+                                        :user (if vemv?
+                                                "root"
+                                                "postgres")
+                                        :password (if vemv?
+                                                    ""
+                                                    "postgres")})
    :pedestal (component/using (pedestal-component/pedestal (constantly playground.server/dev-map))
                               playground.service/components-to-inject)))
 

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -24,7 +24,7 @@
    [playground.service]))
 
 ;; ugly hack, will disappear when we use the newer project template
-(def vemv? (-> (System/getenv "USER") #{"vemv"}))
+(def vemv? (-> (System/getenv "USER") #{"vemv" "victor.valenzuela"}))
 
 (defn dev-system
   []
@@ -32,12 +32,12 @@
    :service-map playground.server/dev-map
    ;; :background-processor (background-processor/new :queue-name "cljtest")
    ;; :enqueuer (enqueuer/new :queue-name "cljtest")
-   :db (modular.postgres/map->Postgres {:url (if vemv?
-                                               "jdbc:postgresql:ebdb"
-                                               "jdbc:postgresql:postgres")
-                                        :user (if vemv?
-                                                "root"
-                                                "postgres")
+   :db (modular.postgres/map->Postgres {:url      (if vemv?
+                                                    "jdbc:postgresql:ebdb"
+                                                    "jdbc:postgresql:postgres")
+                                        :user     (if vemv?
+                                                    "root"
+                                                    "postgres")
                                         :password (if vemv?
                                                     ""
                                                     "postgres")})

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -15,11 +15,12 @@
    [clojure.string :as string]
    [com.grzm.component.pedestal :as pedestal-component]
    [com.stuartsierra.component :as component]
-   [com.stuartsierra.component.repl :refer [set-init]]
+   [com.stuartsierra.component.repl :refer [reset set-init]]
+   [formatting-stack.component]
    [modular.postgres]
+   [playground.server]
    #_ [background-processing.background-processor :as background-processor]
    #_ [background-processing.enqueuer :as enqueuer]
-   [playground.server]
    [playground.service]))
 
 ;; ugly hack, will disappear when we use the newer project template
@@ -41,7 +42,8 @@
                                                     ""
                                                     "postgres")})
    :pedestal (component/using (pedestal-component/pedestal (constantly playground.server/dev-map))
-                              playground.service/components-to-inject)))
+                              playground.service/components-to-inject)
+   :formatting-stack (formatting-stack.component/map->Formatter {})))
 
 (set-init (fn [_]
             (dev-system)))

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,4 +1,4 @@
-(ns dev
+(ns user
   "Tools for interactive development with the REPL. This file should
   not be included in a production build of the application.
 

--- a/project.clj
+++ b/project.clj
@@ -8,11 +8,11 @@
                  #_[background-processing "0.1.0-SNAPSHOT"]
                  [better-cond "1.0.1"]
                  [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
-                 [com.gfredericks/how-to-ns "0.1.9"]
                  [com.grzm/component.pedestal "0.1.7"]
                  [com.mchange/c3p0 "0.9.5.2"]
-                 [com.stuartsierra/component "0.3.2"]
+                 [com.stuartsierra/component "0.4.0"]
                  [expound "0.6.0"]
+                 [formatting-stack "0.10.4"]
                  [honeysql "0.9.4"]
                  [io.pedestal/pedestal.jetty "0.5.3"]
                  [io.pedestal/pedestal.service "0.5.3"]
@@ -33,8 +33,9 @@
   :resource-paths ["config" "resources"]
   :profiles {:dev {:dependencies [[io.pedestal/pedestal.service-tools "0.5.3"]
                                   [com.stuartsierra/component.repl "0.2.0"]
-                                  [org.clojure/tools.namespace "0.2.11"]
+                                  [org.clojure/tools.namespace "0.3.0-alpha4"]
                                   [org.clojure/tools.nrepl "0.2.13" :exclusions [org.clojure/clojure]]]
-                   :source-paths ["dev"]}
+                   :source-paths ["dev"]
+                   :repl-options {:init-ns user}}
              :uberjar {:aot [playground.server]}}
   :main ^{:skip-aot true} playground.server)

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -36,9 +36,6 @@
 (defn insert-page [request]
   (ring-resp/response (views/insert)))
 
-(defn insert-test [request]
-  (ring-resp/response request))
-
 (spec/def ::temperature int?)
 
 (spec/def ::orientation (spec/and keyword? #{:north :south :east :west}))

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -33,6 +33,12 @@
       (ring-resp/not-found "Entry not in DB")
       )))
 
+(defn insert-page [request]
+  (ring-resp/response (views/insert)))
+
+(defn insert-test [request]
+  (ring-resp/response request))
+
 (spec/def ::temperature int?)
 
 (spec/def ::orientation (spec/and keyword? #{:north :south :east :west}))
@@ -86,7 +92,8 @@
     ;;FIXME change the routes definition format from: (def routes #{...})
     ;;to (def routes (io.pedestal.http.route.definition.table/table-routes ...))
     ;;as "/invoices/:id" is conflicting with "/invoices/insert"
-    ["/invoices-insert" :get (into component-interceptors [http/json-body (param-spec-interceptor ::invoices.insert/api :query-params) `invoices.insert/perform])]
+    ["/invoices-insert" :get (conj common-interceptors `insert-page)]
+    ["/invoices-insert" :post (into common-interceptors [http/json-body (param-spec-interceptor ::invoices.insert/api :params) `invoices.insert/perform])]
     ["/invoices/:id" :get (conj common-interceptors (param-spec-interceptor ::invoices.retrieve/api :path-params) `invoice-page)]
     ["/invoices" :get (conj common-interceptors `all-invoices-page)]
     ["/invoices/delete" :get (into component-interceptors [http/json-body `invoices.delete/perform])]

--- a/src/playground/services/invoices/insert/endpoint.clj
+++ b/src/playground/services/invoices/insert/endpoint.clj
@@ -9,7 +9,7 @@
 
 (spec/def ::api (spec/keys :req-un [::amount]))
 
-(defn perform [{{:keys [amount]} :params :keys [db] :as request}]
+(defn perform [{{:keys [amount]} :form-params :keys [db] :as request}]
   (let [db     (->> db :pool (hash-map :datasource))
         insert (-> (logic/to-insert amount (java.util.UUID/randomUUID))
                    (h/format))
@@ -19,4 +19,3 @@
                    (logic/to-serialize))]
     {:status 200
      :body   result}))
-

--- a/src/playground/services/invoices/insert/endpoint.clj
+++ b/src/playground/services/invoices/insert/endpoint.clj
@@ -9,7 +9,7 @@
 
 (spec/def ::api (spec/keys :req-un [::amount]))
 
-(defn perform [{{:keys [amount]} :query-params :keys [db] :as request}]
+(defn perform [{{:keys [amount]} :params :keys [db] :as request}]
   (let [db     (->> db :pool (hash-map :datasource))
         insert (-> (logic/to-insert amount (java.util.UUID/randomUUID))
                    (h/format))
@@ -19,5 +19,4 @@
                    (logic/to-serialize))]
     {:status 200
      :body   result}))
-
 

--- a/src/playground/services/invoices/retrieve_all/logic.clj
+++ b/src/playground/services/invoices/retrieve_all/logic.clj
@@ -2,5 +2,5 @@
 
 (defn query-all []
   {:select [:*]
-   :from [:users]
-   :limit 100})
+   :from   [:users]
+   :limit  100})

--- a/src/playground/services/invoices/retrieve_all/logic.clj
+++ b/src/playground/services/invoices/retrieve_all/logic.clj
@@ -2,4 +2,5 @@
 
 (defn query-all []
   {:select [:*]
-   :from [:users]})
+   :from [:users]
+   :limit 100})

--- a/src/playground/views.clj
+++ b/src/playground/views.clj
@@ -70,5 +70,5 @@
      [:h1 "Add an entry to the DB"]
      [:form {:action "/invoices-insert" :method "POST"}
       [:div
-       [:p [:label.justify "amount: " [:input {:type "text" :name "amount"}]]]
-       [:p [:label.justify "λ ->" [:input {:type "submit" :value "Submit"}]]]]]]))
+       [:p [:label "amount: " [:input {:type "text" :name "amount"}]]]
+       [:p [:label "λ ->" [:input {:type "submit" :value "Submit"}]]]]]]))

--- a/src/playground/views.clj
+++ b/src/playground/views.clj
@@ -60,3 +60,15 @@
    [:div
     [:h1 "Invoice"]
     [:p (str user)]]))
+
+
+(defn insert []
+  (page/html5
+   (gen-page-head "Add an entry")
+    header-links
+    [:div
+     [:h1 "Add an entry to the DB"]
+     [:form {:action "/invoices-insert" :method "POST"}
+      [:div
+       [:p [:label.justify "amount: " [:input {:type "text" :name "amount"}]]]
+       [:p [:label.justify "λ ->" [:input {:type "submit" :value "Submit"}]]]]]]))


### PR DESCRIPTION
The route "/invoices-insert" POST returns a param-map that needs coercing (is that the term?) to keywords (i.e `{"amount" "12"} -> {:amount 12} `). 
I saw it done with `json-read` using a `:key-fn` `keyword`  but with the current interceptors situation I am not sure how can this be applied.
All this assuming that I am right, and the reason that the map returned to the POST method raises an exception is the format.