### PR TITLE
authorization

### DIFF
--- a/src/playground/models/user.clj
+++ b/src/playground/models/user.clj
@@ -3,8 +3,8 @@
             [clojure.string :as string]))
 
 (spec/def ::username (spec/and string? seq (complement clojure.string/blank?)))
-(spec/def ::password (spec/and string? seq (complement clojure.string/blank?)))
-(spec/def ::name (spec/and string? seq (complement string/blank?)))
+(spec/def ::password ::username)
+(spec/def ::name ::username)
 
 (spec/def ::id nat-int?)
 

--- a/src/playground/models/user.clj
+++ b/src/playground/models/user.clj
@@ -2,9 +2,10 @@
   (:require [clojure.spec.alpha :as spec]
             [clojure.string :as string]))
 
-(spec/def ::username (spec/and string? seq (complement clojure.string/blank?)))
-(spec/def ::password ::username)
-(spec/def ::name ::username)
+(spec/def ::present-string (spec/and string? seq (complement clojure.string/blank?)))
+(spec/def ::username ::present-string)
+(spec/def ::password ::present-string)
+(spec/def ::name ::present-string)
 
 (spec/def ::id nat-int?)
 

--- a/src/playground/models/user.clj
+++ b/src/playground/models/user.clj
@@ -10,3 +10,4 @@
 
 (spec/def ::amount nat-int?)
 
+(def admin-role "admin")

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -24,7 +24,7 @@
    [ring.middleware.session.cookie :as cookie]
    [ring.middleware.flash :as flash]
    [buddy.auth.middleware :refer [authentication-request]]
-   [buddy.auth.backends :refer [basic]]
+   [buddy.auth.backends :as auth.backends]
    [buddy.auth :refer [authenticated?]]
    [buddy.hashers :as hashers]))
 
@@ -63,13 +63,8 @@
 ;;auth interceptors
 
 (def session-auth-backend
-  (basic
-   {:authfn (fn [request]
-              (let [username (get-in request [:session :identity :username])
-                    password (get-in request [:session :identity :password])]
-                (if (= (session.login/password-by-username request username) (hashers/derive password))
-                  username
-                  )))}))
+  (auth.backends/session
+   ))
 
 (def authentication-interceptor
   "Port of buddy-auth's wrap-authentication middleware."

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -80,7 +80,7 @@
                (if (authenticated? session)
                  (update context :request authentication-request session-auth-backend)
                  (-> context
-                        (assoc :response {:status 403
+                        (assoc :response {:status 401
                                           :body   "must login for that..."})
                         interceptor-chain/terminate))))}))
 
@@ -150,7 +150,7 @@
     ["/invoices-update/:id" :post (into common-interceptors [http/json-body (param-spec-interceptor ::invoices.update/api :form-params) `invoices.update/perform])]
     ["/invoices/:id" :get (into common-interceptors [authentication-interceptor (param-spec-interceptor ::invoices.retrieve/api :path-params) `invoices.retrieve/perform]) :route-name :invoices/:id]
     ["/invoices" :get (conj common-interceptors `invoices.retrieve-all/perform) :route-name :invoices]
-    ["/invoices-delete/:id" :get (into common-interceptors [http/json-body admin-interceptor (param-spec-interceptor ::invoices.delete/api :path-params) `invoices.delete/perform]) :route-name :invoices-delete/:id]
+    ["/invoices-delete/:id" :get (into common-interceptors [http/json-body authentication-interceptor admin-interceptor (param-spec-interceptor ::invoices.delete/api :path-params) `invoices.delete/perform]) :route-name :invoices-delete/:id]
     })
 
 (comment

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -86,7 +86,10 @@
             (let [role (get-in context [:request :session :identity :role])]
               (if (= role models.user/admin-role)
                 context
-                (throw-unauthorized)
+                (-> context
+                    (assoc :response {:status 403
+                                      :body   "Unauthorized"})
+                    interceptor-chain/terminate)
                 )))})
 
 ;;;;;;;;;;;;;;;;;;;

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -5,7 +5,7 @@
    [com.grzm.component.pedestal :as pedestal-component]
    [io.pedestal.http :as http]
    [io.pedestal.http.body-params :as body-params]
-   [io.pedestal.http.route :as route]
+   [io.pedestal.http.route :refer [url-for] :as route]
    [io.pedestal.interceptor :as interceptor]
    [io.pedestal.interceptor.chain :as interceptor-chain]
    [io.pedestal.http.ring-middlewares :as ring-middlewares]
@@ -33,7 +33,10 @@
   (ring-resp/response (views/home request)))
 
 (defn insert-page [request]
-  (ring-resp/response (views/insert request)))
+  (if (authenticated? (:session request))
+    (ring-resp/response (views/insert request))
+    (-> (ring-resp/redirect (url-for :invoices))
+        (assoc :flash "login to add entries"))))
 
 (defn register-page [request]
   (ring-resp/response (views/register request)))

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -23,7 +23,8 @@
    [ring.middleware.session.cookie :as cookie]
    [ring.middleware.flash :as flash]
    [buddy.auth.middleware :refer [authentication-request]]
-   [buddy.auth.backends.session :refer [session-backend]]))
+   [buddy.auth.backends.session :refer [session-backend]]
+   [buddy.auth :refer [authenticated? throw-unauthorized]]))
 
 (defn about-page [request]
   (ring-resp/response (views/about request)))

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -25,7 +25,8 @@
    [ring.middleware.flash :as flash]
    [buddy.auth.middleware :refer [authentication-request]]
    [buddy.auth.backends.session :refer [session-backend]]
-   [buddy.auth :refer [authenticated? throw-unauthorized]]))
+   [buddy.auth :refer [authenticated? throw-unauthorized]]
+   [buddy.hashers :as hashers]))
 
 (defn about-page [request]
   (ring-resp/response (views/about request)))
@@ -68,8 +69,8 @@
   (session-backend
    {:authfn (fn [request]
               (let [{:keys [username password]} request]
-                (when (= (session.login/password-by-username username) password)
-                  {:username username :password password})))}))
+                (when (= (session.login/password-by-username request username) (hashers/derive password))
+                  {:username username :password (hashers/derive password) :role (session.login/get-role request username)})))}))
 
 (def authentication-interceptor
   "Port of buddy-auth's wrap-authentication middleware."

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -79,9 +79,9 @@
     :enter (fn [context]
              (update context :request authentication-request session-auth-backend))}))
 
-(def authorization-interceptor
-  "throw unautherize by role"
-  {:name ::authorize
+(def admin-interceptor
+  "throw unautherized 403 by role (allows admin only)"
+  {:name ::admin-interceptor
    :enter (fn [context]
             (let [role (get-in context [:request :session :identity :role])]
               (if (= role models.user/admin-role)
@@ -145,7 +145,7 @@
     ["/invoices-update/:id" :post (into common-interceptors [http/json-body (param-spec-interceptor ::invoices.update/api :form-params) `invoices.update/perform])]
     ["/invoices/:id" :get (conj common-interceptors (param-spec-interceptor ::invoices.retrieve/api :path-params) `invoices.retrieve/perform) :route-name :invoices/:id]
     ["/invoices" :get (conj common-interceptors `invoices.retrieve-all/perform) :route-name :invoices]
-    ["/invoices-delete/:id" :get (into common-interceptors [http/json-body authorization-interceptor (param-spec-interceptor ::invoices.delete/api :path-params) `invoices.delete/perform]) :route-name :invoices-delete/:id]
+    ["/invoices-delete/:id" :get (into common-interceptors [http/json-body admin-interceptor (param-spec-interceptor ::invoices.delete/api :path-params) `invoices.delete/perform]) :route-name :invoices-delete/:id]
     })
 
 (comment

--- a/src/playground/services/invoices/delete/endpoint.clj
+++ b/src/playground/services/invoices/delete/endpoint.clj
@@ -12,18 +12,9 @@
 (spec/def ::api (spec/keys :req-un [::models.user/id]))
 
 (defn perform [{{:keys [id]} :path-params :keys [db session] :as request}]
-  (let  [role (get-in session [:identity :role])]
-    (let [db (->> db :pool (hash-map :datasource))
-          _  (->> (logic/to-delete id)
-                  (h/format)
-                  (jdbc/execute! db))
-          fetch  (h/format (retrieve-all.logic/query-all))
-          left   (->> (logic/to-serialize)
-                      (h/format)
-                      (jdbc/query db)
-                      (first))
-          result (jdbc/query db fetch)
-          result-map {:result result :deleted id}]
-      (-> (ring-resp/redirect (url-for :invoices))
-          (assoc :flash (str "Entry " id " has beed deleted."))))
-    ))
+  (let [db (->> db :pool (hash-map :datasource))
+        _  (->> (logic/to-delete id)
+                (h/format)
+                (jdbc/execute! db))]
+    (-> (ring-resp/redirect (url-for :invoices))
+        (assoc :flash (str "Entry " id " has beed deleted.")))))

--- a/src/playground/services/invoices/delete/endpoint.clj
+++ b/src/playground/services/invoices/delete/endpoint.clj
@@ -14,18 +14,17 @@
 
 (defn perform [{{:keys [id]} :path-params :keys [db session] :as request}]
   (let  [role (get-in session [:identity :role])]
-    (if (= "admin" role)
-      (let [db (->> db :pool (hash-map :datasource))
-            _  (->> (logic/to-delete id)
-                    (h/format)
-                    (jdbc/execute! db))
-            fetch  (h/format (retrieve-all.logic/query-all))
-            left   (->> (logic/to-serialize)
-                        (h/format)
-                        (jdbc/query db)
-                        (first))
-            result (jdbc/query db fetch)
-            result-map {:result result :deleted id}]
-        (-> (ring-resp/redirect (url-for :invoices))
-            (assoc :flash (str "Entry " id " has beed deleted."))))
-      (throw-unauthorized))))
+    (let [db (->> db :pool (hash-map :datasource))
+          _  (->> (logic/to-delete id)
+                  (h/format)
+                  (jdbc/execute! db))
+          fetch  (h/format (retrieve-all.logic/query-all))
+          left   (->> (logic/to-serialize)
+                      (h/format)
+                      (jdbc/query db)
+                      (first))
+          result (jdbc/query db fetch)
+          result-map {:result result :deleted id}]
+      (-> (ring-resp/redirect (url-for :invoices))
+          (assoc :flash (str "Entry " id " has beed deleted."))))
+    ))

--- a/src/playground/services/invoices/delete/endpoint.clj
+++ b/src/playground/services/invoices/delete/endpoint.clj
@@ -3,7 +3,6 @@
    [clojure.spec.alpha :as spec]
    [clojure.java.jdbc :as jdbc]
    [honeysql.core :as h]
-   [buddy.auth :refer [authenticated? throw-unauthorized]]
    [io.pedestal.http.route :refer (url-for)]
    [playground.services.invoices.delete.logic :as logic]
    [playground.services.invoices.retrieve-all.logic :as retrieve-all.logic]

--- a/src/playground/services/invoices/delete/endpoint.clj
+++ b/src/playground/services/invoices/delete/endpoint.clj
@@ -3,22 +3,29 @@
    [clojure.spec.alpha :as spec]
    [clojure.java.jdbc :as jdbc]
    [honeysql.core :as h]
+   [buddy.auth :refer [authenticated? throw-unauthorized]]
+   [io.pedestal.http.route :refer (url-for)]
    [playground.services.invoices.delete.logic :as logic]
    [playground.services.invoices.retrieve-all.logic :as retrieve-all.logic]
-   [playground.models.user :as models.user]))
+   [playground.models.user :as models.user]
+   [ring.util.response :as ring-resp]))
 
 (spec/def ::api (spec/keys :req-un [::models.user/id]))
 
-(defn perform [{{:keys [id]} :path-params :keys [db] :as request}]
-  (let [db (->> db :pool (hash-map :datasource))
-        _  (->> (logic/to-delete id)
-                (h/format)
-                (jdbc/execute! db))
-        fetch  (h/format (retrieve-all.logic/query-all))
-        left   (->> (logic/to-serialize)
+(defn perform [{{:keys [id]} :path-params :keys [db session] :as request}]
+  (let  [role (get-in session [:identity :role])]
+    (if (= "admin" role)
+      (let [db (->> db :pool (hash-map :datasource))
+            _  (->> (logic/to-delete id)
                     (h/format)
-                    (jdbc/query db)
-                    (first))
-        result (jdbc/query db fetch)
-        result-map {:result result :deleted id}]
-    {:status 302 :headers {"Location" "/invoices"} :body "" :flash (str "Entry " id " has beed deleted.")}))
+                    (jdbc/execute! db))
+            fetch  (h/format (retrieve-all.logic/query-all))
+            left   (->> (logic/to-serialize)
+                        (h/format)
+                        (jdbc/query db)
+                        (first))
+            result (jdbc/query db fetch)
+            result-map {:result result :deleted id}]
+        (-> (ring-resp/redirect (url-for :invoices))
+            (assoc :flash (str "Entry " id " has beed deleted."))))
+      (throw-unauthorized))))

--- a/src/playground/services/invoices/retrieve/endpoint.clj
+++ b/src/playground/services/invoices/retrieve/endpoint.clj
@@ -9,7 +9,6 @@
    [playground.services.invoices.retrieve.logic :as logic]
    [playground.services.invoices.retrieve.view :as view]
    [playground.models.user :as models.user]
-   [buddy.auth :refer [authenticated? throw-unauthorized]]
    [playground.views :as views])
   (:import
    [org.postgresql.jdbc4 Jdbc4Array]))
@@ -20,15 +19,11 @@
 (spec/def ::api (spec/keys :req-un [::models.user/id]))
 
 (defn perform [{{:keys [id]} :path-params :keys [session db] :as request}]
-  (if (authenticated? session)
-      (let [db     (->> db :pool (hash-map :datasource))
-            record (->> (logic/to-query id)
-                        (h/format)
-                        (jdbc/query db)
-                        (first))]
-        (if record
-          (ring-resp/response (view/update-invoice record))
-          {:status 404 :body "Entry not in DB"}))
-      (-> (ring-resp/redirect (url-for :invoices))
-          (assoc :flash "you must login to edit any entries"))
-      ))
+  (let [db     (->> db :pool (hash-map :datasource))
+        record (->> (logic/to-query id)
+                    (h/format)
+                    (jdbc/query db)
+                    (first))]
+    (if record
+      (ring-resp/response (view/update-invoice request record))
+      {:status 404 :body "Entry not in DB"})))

--- a/src/playground/services/invoices/retrieve/endpoint.clj
+++ b/src/playground/services/invoices/retrieve/endpoint.clj
@@ -5,9 +5,12 @@
    [clojure.spec.alpha :as spec]
    [honeysql.core :as h]
    [ring.util.response :as ring-resp]
+   [io.pedestal.http.route :refer [url-for]]
    [playground.services.invoices.retrieve.logic :as logic]
    [playground.services.invoices.retrieve.view :as view]
-   [playground.models.user :as models.user])
+   [playground.models.user :as models.user]
+   [buddy.auth :refer [authenticated? throw-unauthorized]]
+   [playground.views :as views])
   (:import
    [org.postgresql.jdbc4 Jdbc4Array]))
 
@@ -16,12 +19,16 @@
 
 (spec/def ::api (spec/keys :req-un [::models.user/id]))
 
-(defn perform [{{:keys [id]} :path-params :keys [db] :as request}]
-  (let [db     (->> db :pool (hash-map :datasource))
-        record (->> (logic/to-query id)
-                    (h/format)
-                    (jdbc/query db)
-                    (first))]
-    (if record
-      (ring-resp/response (view/update-invoice record))
-      {:status 404 :body "Entry not in DB"})))
+(defn perform [{{:keys [id]} :path-params :keys [session db] :as request}]
+  (if (authenticated? session)
+      (let [db     (->> db :pool (hash-map :datasource))
+            record (->> (logic/to-query id)
+                        (h/format)
+                        (jdbc/query db)
+                        (first))]
+        (if record
+          (ring-resp/response (view/update-invoice record))
+          {:status 404 :body "Entry not in DB"}))
+      (-> (ring-resp/redirect (url-for :invoices))
+          (assoc :flash "you must login to edit any enries"))
+      ))

--- a/src/playground/services/invoices/retrieve/endpoint.clj
+++ b/src/playground/services/invoices/retrieve/endpoint.clj
@@ -30,5 +30,5 @@
           (ring-resp/response (view/update-invoice record))
           {:status 404 :body "Entry not in DB"}))
       (-> (ring-resp/redirect (url-for :invoices))
-          (assoc :flash "you must login to edit any enries"))
+          (assoc :flash "you must login to edit any entries"))
       ))

--- a/src/playground/services/invoices/retrieve/logic.clj
+++ b/src/playground/services/invoices/retrieve/logic.clj
@@ -4,4 +4,3 @@
   {:select [:*]
    :from   [:users]
    :where  [:= :id id]})
-

--- a/src/playground/services/invoices/retrieve/view.clj
+++ b/src/playground/services/invoices/retrieve/view.clj
@@ -3,10 +3,10 @@
             [playground.views :as views]))
 
 
-(defn update-invoice [user]
+(defn update-invoice [request user]
   (page/html5
    (views/gen-page-head "Invoice")
-   (views/header-links user)
+   (views/header-links request)
    [:div
     [:h1 (str "Update user id: " (:id user))]
     [:form {:action (str "/invoices-update/" (:id user)) :method "POST"}

--- a/src/playground/services/invoices/update/endpoint.clj
+++ b/src/playground/services/invoices/update/endpoint.clj
@@ -21,4 +21,3 @@
 
     (-> (ring-resp/redirect (url-for :invoices))
         (assoc :flash (str "Entry " id " has been updated")))))
-

--- a/src/playground/services/session/login/endpoint.clj
+++ b/src/playground/services/session/login/endpoint.clj
@@ -31,7 +31,7 @@
         session (:session request)]
     (if (logic/check-password password (:password (password-by-username request username)))
       (let [next-url (get-in request [:query-params :next] "/")
-            updated-session (assoc session :identity (conj {:username username :password password} (get-role request username)))]
+            updated-session (assoc session :identity (conj {:username username} (get-role request username)))]
                  (-> (ring-resp/redirect next-url)
                      (assoc :session updated-session)))
       (-> (ring-resp/redirect (url-for :login))

--- a/src/playground/services/session/login/endpoint.clj
+++ b/src/playground/services/session/login/endpoint.clj
@@ -18,13 +18,20 @@
          (first))
     ))
 
+(defn get-role [{:keys [db] :as request} username]
+  (let [db (->> db :pool (hash-map :datasource))]
+    (->> (logic/role username)
+        (h/format)
+        (jdbc/query db)
+        (first))))
+
 (defn perform [request]
   (let [username (get-in request [:form-params :username])
         password (get-in request [:form-params :password])
         session (:session request)]
     (if (logic/check-password password (:password (password-by-username request username)))
       (let [next-url (get-in request [:query-params :next] "/")
-            updated-session (assoc session :identity {:username username :password password :role (logic/role username)})]
+            updated-session (assoc session :identity (conj {:username username :password password} (get-role request username)))]
                  (-> (ring-resp/redirect next-url)
                      (assoc :session updated-session)))
       (-> (ring-resp/redirect (url-for :login))

--- a/src/playground/services/session/login/endpoint.clj
+++ b/src/playground/services/session/login/endpoint.clj
@@ -24,7 +24,7 @@
         session (:session request)]
     (if (logic/check-password password (:password (password-by-username request username)))
       (let [next-url (get-in request [:query-params :next] "/")
-            updated-session (assoc session :identity {:username username :password password})]
+            updated-session (assoc session :identity {:username username :password password :role (logic/role username)})]
                  (-> (ring-resp/redirect next-url)
                      (assoc :session updated-session)))
       (-> (ring-resp/redirect (url-for :login))

--- a/src/playground/services/session/login/logic.clj
+++ b/src/playground/services/session/login/logic.clj
@@ -16,3 +16,7 @@
 (defn check-password [password encrypted]
   (hashers/check password encrypted))
 
+(defn role [username]
+  (-> (select :role)
+      (from :register)
+      (where [:= :username username])))

--- a/src/playground/views.clj
+++ b/src/playground/views.clj
@@ -30,8 +30,6 @@
      " | "
      [:a {:href "/about"} "About"]
      " | "
-     [:a {:href "/invoices-insert"} "Add an entry"]
-     " | "
      [:a {:href "/invoices"} "All Entries"]
      " | "
      [:a {:href "/register"} "Register"]


### PR DESCRIPTION
## Goal
Limit user access to content and functionality by identity and role.

## Proposed changes
- Add username ( from :identity) to the table users upon entry, in order to limit editing to the author and the admin.
- limit deletion to admin only.
- change users table altogether to something else ( in the "hirundia" project it is (address, number, height, date ....username) -> to avoid confusion (user/username) what do you think @vemv ?  
## PR status, roadblocks, etc
- The authentication is now done by the interceptors (`authentication-interceptor` and `authorization-interceptor`)
  
 
 
