### PR TITLE
authorize update entry to author only

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It requires to have the following namespaces required:
 
 For the service.invoices ns create a table:
 
-`CREATE TABLE users (id SERIAL, email VARCHAR(50))`
+`CREATE TABLE users (id SERIAL, email VARCHAR(50), authored VARCHAR(20))`
 
 and register table that keeps auth login data:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ It requires to have the following namespaces required:
 
 For the service.invoices ns create a table:
 
-`CREATE TABLE users (id SERIAL, email VARCHAR(50), authored VARCHAR(20))`
+
 
 and register table that keeps auth login data:
 

--- a/src/playground/models/user.clj
+++ b/src/playground/models/user.clj
@@ -2,7 +2,7 @@
   (:require [clojure.spec.alpha :as spec]
             [clojure.string :as string]))
 
-(spec/def ::username (spec/and string? seq (complement clojure.string/blank?)))
+(spec/def ::username (spec/and string? seq (complement string/blank?)))
 (spec/def ::password ::username)
 (spec/def ::name ::username)
 

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -104,7 +104,7 @@
                   username (get-in context [:request :session :identity :username])
                   id       (get-in context [:request :path-params :id])
                   db       (get-in context [:request :db])
-                  author (:author (invoices.retrieve/return-author (:request context)))]
+                  author (:author (invoices.retrieve/get-author (:request context)))]
               (if (or (= role models.user/admin-role) (= username author))
                 context
                 (-> context

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -28,6 +28,9 @@
    [buddy.auth :refer [authenticated?]]
    [buddy.hashers :as hashers]))
 
+(defn test-page [request]
+  (ring-resp/response (str (get-in request [:session :identity :username]))))
+
 (defn about-page [request]
   (ring-resp/response (views/about request)))
 
@@ -101,8 +104,8 @@
                   username (get-in context [:request :session :identity :username])
                   id       (get-in context [:request :path-params :id])
                   db       (get-in context [:request :db])
-                  authored (:authored (invoices.retrieve/return-authored (:request context)))]
-              (if (or (= role models.user/admin-role) (= username authored))
+                  author (:author (invoices.retrieve/return-author (:request context)))]
+              (if (or (= role models.user/admin-role) (= username author))
                 context
                 (-> context
                     (assoc :response {:status 403
@@ -150,6 +153,7 @@
   "Tabular routes"
   #{["/" :get (conj common-interceptors `home-page) :route-name :home]
     ["/about" :get (conj common-interceptors `about-page)]
+    ["/test" :get (conj common-interceptors `test-page)]
     ["/api" :get (into component-interceptors [http/json-body (param-spec-interceptor ::api :query-params) `api])]
     ;;FIXME change the routes definition format from: (def routes #{...})
     ;;to (def routes (io.pedestal.http.route.definition.table/table-routes ...))

--- a/src/playground/service.clj
+++ b/src/playground/service.clj
@@ -101,7 +101,7 @@
                   username (get-in context [:request :session :identity :username])
                   id       (get-in context [:request :path-params :id])
                   db       (get-in context [:request :db])
-                  authored (invoices.retrieve/return-authored (:request context))]
+                  authored (:authored (invoices.retrieve/return-authored (:request context)))]
               (if (or (= role models.user/admin-role) (= username authored))
                 context
                 (-> context

--- a/src/playground/services/invoices/delete/endpoint.clj
+++ b/src/playground/services/invoices/delete/endpoint.clj
@@ -11,19 +11,18 @@
 
 (spec/def ::api (spec/keys :req-un [::models.user/id]))
 
-(defn perform [{{:keys [id]} :path-params :keys [db session] :as request}]
-  (let  [role (get-in session [:identity :role])]
-    (let [db (->> db :pool (hash-map :datasource))
-          _  (->> (logic/to-delete id)
-                  (h/format)
-                  (jdbc/execute! db))
-          fetch  (h/format (retrieve-all.logic/query-all))
-          left   (->> (logic/to-serialize)
-                      (h/format)
-                      (jdbc/query db)
-                      (first))
-          result (jdbc/query db fetch)
-          result-map {:result result :deleted id}]
-      (-> (ring-resp/redirect (url-for :invoices))
-          (assoc :flash (str "Entry " id " has beed deleted."))))
-    ))
+(defn perform [{{:keys [id]} :path-params :keys [db] :as request}]
+  (let [db (->> db :pool (hash-map :datasource))
+        _  (->> (logic/to-delete id)
+                (h/format)
+                (jdbc/execute! db))
+        fetch  (h/format (retrieve-all.logic/query-all))
+        left   (->> (logic/to-serialize)
+                    (h/format)
+                    (jdbc/query db)
+                    (first))
+        result (jdbc/query db fetch)
+        result-map {:result result :deleted id}]
+    (-> (ring-resp/redirect (url-for :invoices))
+        (assoc :flash (str "Entry " id " has beed deleted."))))
+    )

--- a/src/playground/services/invoices/insert/endpoint.clj
+++ b/src/playground/services/invoices/insert/endpoint.clj
@@ -8,9 +8,11 @@
 
 (spec/def ::api (spec/keys :req-un [::models.user/amount]))
 
-(defn perform [{{:keys [amount]} :form-params :keys [db] :as request}]
+(defn perform [{{:keys [amount]} :form-params :keys [db session] :as request}]
   (let [db     (->> db :pool (hash-map :datasource))
-        insert (-> (logic/to-insert amount (java.util.UUID/randomUUID))
+        insert (-> (logic/to-insert amount
+                                    (java.util.UUID/randomUUID)
+                                    session)
                    (h/format))
         _      (jdbc/execute! db insert)
         ]

--- a/src/playground/services/invoices/insert/endpoint.clj
+++ b/src/playground/services/invoices/insert/endpoint.clj
@@ -12,7 +12,7 @@
   (let [db     (->> db :pool (hash-map :datasource))
         insert (-> (logic/to-insert amount
                                     (java.util.UUID/randomUUID)
-                                    session)
+                                    (get-in session [:identity :username]))
                    (h/format))
         _      (jdbc/execute! db insert)
         ]

--- a/src/playground/services/invoices/insert/logic.clj
+++ b/src/playground/services/invoices/insert/logic.clj
@@ -2,10 +2,10 @@
   (:require
    [honeysql.helpers :as hh]))
 
-(defn to-insert [amount random-uuid session]
+(defn to-insert [amount random-uuid username]
   (-> (hh/insert-into :users)
       (hh/values [{:email (str amount "@" random-uuid ".com")
-                   :author (get-in session [:identity :username])}])))
+                   :author username}])))
 
 (def to-query
   {:select   [:id :email :author]

--- a/src/playground/services/invoices/insert/logic.clj
+++ b/src/playground/services/invoices/insert/logic.clj
@@ -2,15 +2,16 @@
   (:require
    [honeysql.helpers :as hh]))
 
-(defn to-insert [amount random-uuid]
+(defn to-insert [amount random-uuid session]
   (-> (hh/insert-into :users)
-      (hh/values [{:email (str amount "@" random-uuid ".com")}])))
+      (hh/values [{:email (str amount "@" random-uuid ".com")
+                   :authored (get-in session [:identity :username])}])))
 
 (def to-query
-  {:select   [:id :email]
+  {:select   [:id :email :authored]
    :from     [:users]
    :order-by [[:id :desc]]
    :limit    1})
 
 (defn to-serialize [results]
-  (-> results first (select-keys [:id :email])))
+  (-> results first (select-keys [:id :email :authored])))

--- a/src/playground/services/invoices/insert/logic.clj
+++ b/src/playground/services/invoices/insert/logic.clj
@@ -5,13 +5,13 @@
 (defn to-insert [amount random-uuid session]
   (-> (hh/insert-into :users)
       (hh/values [{:email (str amount "@" random-uuid ".com")
-                   :authored (get-in session [:identity :username])}])))
+                   :author (get-in session [:identity :username])}])))
 
 (def to-query
-  {:select   [:id :email :authored]
+  {:select   [:id :email :author]
    :from     [:users]
    :order-by [[:id :desc]]
    :limit    1})
 
 (defn to-serialize [results]
-  (-> results first (select-keys [:id :email :authored])))
+  (-> results first (select-keys [:id :email :author])))

--- a/src/playground/services/invoices/retrieve/endpoint.clj
+++ b/src/playground/services/invoices/retrieve/endpoint.clj
@@ -28,9 +28,9 @@
       (ring-resp/response (view/update-invoice request record))
       {:status 404 :body "Entry not in DB"})))
 
-(defn return-authored [{{:keys [id]} :path-params :keys [db] :as request}]
+(defn return-author [{{:keys [id]} :path-params :keys [db] :as request}]
   (let [db     (->> db :pool (hash-map :datasource))
-        record (->> (logic/get-authored id)
+        record (->> (logic/get-author id)
                     (h/format)
                     (jdbc/query db)
                     (first))]

--- a/src/playground/services/invoices/retrieve/endpoint.clj
+++ b/src/playground/services/invoices/retrieve/endpoint.clj
@@ -28,9 +28,10 @@
       (ring-resp/response (view/update-invoice request record))
       {:status 404 :body "Entry not in DB"})))
 
-(defn return-authored [{{:keys [id]} :path-params :keys [session db] :as request}]
+(defn return-authored [{{:keys [id]} :path-params :keys [db] :as request}]
   (let [db     (->> db :pool (hash-map :datasource))
         record (->> (logic/get-authored id)
                     (h/format)
                     (jdbc/query db)
-                    (first))]))
+                    (first))]
+    record))

--- a/src/playground/services/invoices/retrieve/endpoint.clj
+++ b/src/playground/services/invoices/retrieve/endpoint.clj
@@ -28,7 +28,7 @@
       (ring-resp/response (view/update-invoice request record))
       {:status 404 :body "Entry not in DB"})))
 
-(defn return-author [{{:keys [id]} :path-params :keys [db] :as request}]
+(defn get-author [{{:keys [id]} :path-params :keys [db] :as request}]
   (let [db     (->> db :pool (hash-map :datasource))
         record (->> (logic/get-author id)
                     (h/format)

--- a/src/playground/services/invoices/retrieve/endpoint.clj
+++ b/src/playground/services/invoices/retrieve/endpoint.clj
@@ -27,3 +27,10 @@
     (if record
       (ring-resp/response (view/update-invoice request record))
       {:status 404 :body "Entry not in DB"})))
+
+(defn return-authored [{{:keys [id]} :path-params :keys [session db] :as request}]
+  (let [db     (->> db :pool (hash-map :datasource))
+        record (->> (logic/get-authored id)
+                    (h/format)
+                    (jdbc/query db)
+                    (first))]))

--- a/src/playground/services/invoices/retrieve/logic.clj
+++ b/src/playground/services/invoices/retrieve/logic.clj
@@ -5,7 +5,7 @@
    :from   [:users]
    :where  [:= :id id]})
 
-(defn get-authored [id]
-  {:select [:authored]
+(defn get-author [id]
+  {:select [:author]
    :from [:users]
    :where [:= :id id]})

--- a/src/playground/services/invoices/retrieve/logic.clj
+++ b/src/playground/services/invoices/retrieve/logic.clj
@@ -4,3 +4,8 @@
   {:select [:*]
    :from   [:users]
    :where  [:= :id id]})
+
+(defn get-authored [id]
+  {:select [:authored]
+   :from [:users]
+   :where [:= :id id]})

--- a/src/playground/services/invoices/retrieve_all/view.clj
+++ b/src/playground/services/invoices/retrieve_all/view.clj
@@ -24,7 +24,7 @@
            extended-context (map #(assoc % :delete (:id %)) context)]
        (table/to-table1d
         extended-context
-        [:id "ID" :email "Email" :authored "Authored-by" :delete "to-delete"]
+        [:id "ID" :email "Email" :author "Author" :delete "to-delete"]
         attr-fns))]]))
 
 

--- a/src/playground/services/invoices/retrieve_all/view.clj
+++ b/src/playground/services/invoices/retrieve_all/view.clj
@@ -24,7 +24,7 @@
            extended-context (map #(assoc % :delete (:id %)) context)]
        (table/to-table1d
         extended-context
-        [:id "ID" :email "Email" :delete "to-delete"]
+        [:id "ID" :email "Email" :authored "Authored-by" :delete "to-delete"]
         attr-fns))]]))
 
 

--- a/src/playground/services/invoices/update/endpoint.clj
+++ b/src/playground/services/invoices/update/endpoint.clj
@@ -12,7 +12,7 @@
 
 (spec/def ::api (spec/keys :req-un [::models.user/name]))
 
-(defn perform [{{:keys [name]} :form-params {:keys [id]} :path-params :keys [db] :as request}]
+(defn perform [{{:keys [name]} :form-params {:keys [id]} :path-params :keys [db session] :as request}]
   (let [db     (->> db :pool (hash-map :datasource))
         update (-> (logic/to-update (Integer/parseInt id) name (java.util.UUID/randomUUID))
                    (h/format))

--- a/src/playground/services/invoices/update/logic.clj
+++ b/src/playground/services/invoices/update/logic.clj
@@ -9,10 +9,10 @@
       (hh/where [:= :id id])))
 
 (def to-query
-  {:select   [:id :email :authored]
+  {:select   [:id :email :author]
    :from     [:users]
    :order-by [[:id :desc]]
    :limit    1})
 
 (defn to-serialize [results]
-  (-> results first (select-keys [:id :email :authored])))
+  (-> results first (select-keys [:id :email :author])))

--- a/src/playground/services/invoices/update/logic.clj
+++ b/src/playground/services/invoices/update/logic.clj
@@ -9,10 +9,10 @@
       (hh/where [:= :id id])))
 
 (def to-query
-  {:select   [:id :email]
+  {:select   [:id :email :authored]
    :from     [:users]
    :order-by [[:id :desc]]
    :limit    1})
 
 (defn to-serialize [results]
-  (-> results first (select-keys [:id :email])))
+  (-> results first (select-keys [:id :email :authored])))

--- a/src/playground/services/session/login/endpoint.clj
+++ b/src/playground/services/session/login/endpoint.clj
@@ -36,5 +36,3 @@
                      (assoc :session updated-session)))
       (-> (ring-resp/redirect (url-for :login))
           (assoc :flash "wrong password")))))
-
-

--- a/test/playground/ddeaguilar_test.clj
+++ b/test/playground/ddeaguilar_test.clj
@@ -1,0 +1,57 @@
+(ns playground.ddeaguilar-test
+  (:require [clojure.test :refer :all]
+            [io.pedestal.test :refer :all]
+            [io.pedestal.http :as http]
+            [playground.service :as service]
+            [playground.server :as server]
+            [ring.middleware.session.store :as session.store]
+            [com.stuartsierra.component :as component]
+            [user]))
+
+
+(def system com.stuartsierra.component.repl/system)
+(def service (user/service-fn system))
+
+
+;; Testing via `response-for` adapted from https://github.com/pedestal/pedestal/blob/09dd88c4ce7f89c7fbb7a398077eb970b3785d2d/service/test/io/pedestal/http/ring_middlewares_test.clj#L181-L212
+(defn make-session-store
+  [reader writer deleter]
+  (reify session.store/SessionStore
+    (read-session [_ k] (reader k))
+    (write-session [_ k s] (writer k s))
+    (delete-session [_ k] (deleter k))))
+
+(defn make-service-fn
+  [session-store]
+  (::http/service-fn (http/create-servlet (assoc service/service
+                                                           ::http/enable-session {:store session-store}))))
+
+
+(deftest stub-session-store-test
+  (let [expected-id "boo"
+        session-store (make-session-store (constantly {:id expected-id})
+                                          (constantly nil)
+                                          (constantly nil))
+        service-fn (make-service-fn session-store)]
+    (is (= expected-id (:body (response-for service-fn :get "/test"))))))
+
+
+(def boo-session (make-session-store (constantly {:identity {:username "boo"}})
+                                     (constantly nil)
+                                     (constantly nil)))
+
+(defn make-comp-session
+  [session-store]
+  (::http/service-fn (http/create-servlet (assoc server/dev-map
+                                                 ::http/enable-session {:store session-store}))))
+
+(response-for (make-comp-session boo-session) :get "/")
+
+(comment
+
+ (run-tests)
+
+
+ )
+
+(make-service-fn boo-session)

--- a/test/playground/service_test.clj
+++ b/test/playground/service_test.clj
@@ -3,8 +3,11 @@
             [io.pedestal.http.route :as route]
             [io.pedestal.test :refer [response-for]]
             [io.pedestal.http.route.definition.table :refer [table-routes]]
+            [io.pedestal.http :as http]
             [com.stuartsierra.component :as component]
             [clojure.test :refer :all]
+            [buddy.core.codecs :as codecs]
+            [buddy.core.codecs.base64 :as base64]
             [user]
             [playground.server]
             [playground.service]))
@@ -12,14 +15,68 @@
 (def url-for (route/url-for-routes
               (route/expand-routes playground.service/routes)))
 
-(deftest greeting-test
+#_(def service
+  (::http/service-fn (http/create-servlet playground.service/service)))
+
+
+(def system com.stuartsierra.component.repl/system)
+(def service (user/service-fn system))
+
+(defn make-headers
+  [username password]
+  (let [b64-encoded (base64/encode (str username ":" password))]
+    {"Authorization" (str "Basic " (codecs/bytes->str b64-encoded))}))
+
+(defn GET
+  [service & opts]
+  (apply response-for service :get opts))
+
+
+#_(GET service "/")
+
+;(assoc :session {:identity {:username "noah"}})
+
+(deftest home-test
+  (let [;system com.stuartsierra.component.repl/system
+        ;service (user/service-fn system)
+        {:keys [status body]} (response-for service
+                                            :get
+                                            (url-for :home))]
+    (testing "Anonymous user"
+      (is (= "<!DOCTYPE html>\n<html><head><title>Home</title></head><div>[ <a href=\"/\">Home</a> | <a href=\"/about\">About</a> | <a href=\"/invoices\">All Entries</a> | <a href=\"/register\">Register</a> | <a href=\"/login\">Login</a> ]</div><div><h1>Hello World!</h1></div></html>"
+             (:body (GET service "/")))))
+    (testing "Authenticated user"
+      (is (= "<!DOCTYPE html>\n<html><head><title>Home</title></head><div>[ <a href=\"/\">Home</a> | <a href=\"/about\">About</a> | <a href=\"/invoices-insert\">Add an entry</a> | <a href=\"/invoices\">All Entries</a> | <a href=\"/logout\">Logout</a> ]</div><div><h1>Hello boo!</h1></div></html>"
+             (:body (GET service "/" :headers {:session {:identity {:username "boo"}}})))))))
+
+#_(:body (assoc (GET service "/") :session {:identity {:username "boo"}}))
+
+#_(deftest greeting-test
   (let [system com.stuartsierra.component.repl/system 
         service (user/service-fn system)
         {:keys [status body]} (response-for service
                                             :get
                                             (url-for :home))] 
     (is (= 200 status))                                        
-    (is (= "<!DOCTYPE html>\n<html><head><title>Home</title></head><div>[ <a href=\"/\">Home</a> | <a href=\"/about\">About</a> | <a href=\"/invoices-insert\">Add an entry</a> | <a href=\"/invoices\">All Entries</a> ]</div><div><h1>Hello World!</h1></div></html>" body))))
+    (is (= "<!DOCTYPE html>\n<html><head><title>Home</title></head><div>[ <a href=\"/\">Home</a> | <a href=\"/about\">About</a> | <a href=\"/invoices\">All Entries</a> | <a href=\"/register\">Register</a> | <a href=\"/login\">Login</a> ]</div><div><h1>Hello World!</h1></div></html>" body))))
+
+
+(deftest pedestal-example
+  (is (= 200 (:status (response-for service
+                                    :get (url-for :invoices/:id
+                                                  :path-params {:id 159}))))))
+
+(deftest login
+  (is (= 200 (:status (response-for service
+                                    :get (url-for :login))))))
+(comment
+  
+  (run-tests)
+
+  )
+
+
+
 
 #_(deftest home-page-test
   (is (= (-> service (response-for :get "/") :body)
@@ -46,3 +103,70 @@
           "X-Permitted-Cross-Domain-Policies" "none"
           "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
 
+
+;;comparing requests
+
+(def no-login-request
+  {:protocol                              "HTTP/1.1",
+   :db  {:url      "jdbc:postgresql:postgres",
+                                                                                      :user     "postgres",
+                                                                                      :password "postgres",
+                                                                                      :pool     [ "com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> z8kfsxa29l16ci175669f|7ffecc0b, dataSourceName -> z8kfsxa29l16ci175669f|7ffecc0b ]"]},
+   :async-supported?                      true,
+   :cookies                               {"ring-session" {:value "AiexH+Oj8MjQ3x5+0QbZ0zPyu9JsY+KA2DPBhNUyWT53mkW1VfbH02jjMvjP0+uFUk7zRrHOKnAH0w6jLsj79A==--lcuWSnMEdsEuvDEDdiu7vVIfu+U5j0hajkA8TmpjwA0="}},
+   :remote-addr                           "0:0:0:0:0:0:0:1",
+   :flash                                 nil,
+   :servlet-response                      [ "HTTP/1.1 200 \nDate: Tue, 16 Apr 2019 20:50:00 GMT\r\n\r\n"],
+   :servlet                               [ "io.pedestal.http.servlet.FnServlet@6a723e70"],
+   :headers                               {"origin" "", "host" "localhost:8080", "user-agent" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36", "cookie" "ring-session=AiexH%2BOj8MjQ3x5%2B0QbZ0zPyu9JsY%2BKA2DPBhNUyWT53mkW1VfbH02jjMvjP0%2BuFUk7zRrHOKnAH0w6jLsj79A%3D%3D--lcuWSnMEdsEuvDEDdiu7vVIfu%2BU5j0hajkA8TmpjwA0%3D", "connection" "keep-alive", "upgrade-insecure-requests" "1", "accept" "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8", "accept-language" "en-GB,en-US;q=0.9,en;q=0.8", "accept-encoding" "gzip, deflate, br", "cache-control" "max-age=0"},
+   :server-port                           8080,
+   :servlet-request                       ["Request(GET //localhost:8080/test)@6e4da7e6"],
+   :session/key                           nil,
+   :path-info                             "/test",
+   :url-for                               {:status :pending, :val nil} ,
+   :uri                                   "/test",
+   :server-name                           "localhost",
+   :query-string                          nil,
+   :path-params                           {},
+   :body                                  ["HttpInputOverHTTP@61548cc8[c=0,q=0,[0]=null,s=STREAM]"],
+   :com.grzm.component.pedestal/component {:db {:url "jdbc:postgresql:postgres", :user "postgres", :password "postgres", :pool ["com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> z8kfsxa29l16ci175669f|7ffecc0b, dataSourceName -> z8kfsxa29l16ci175669f|7ffecc0b ]"]}},
+   :scheme                                :http,
+   :request-method                        :get,
+   :session                               {}})
+
+
+
+(def login-request
+  {:protocol                              "HTTP/1.1",
+   :db                                   {:url      "jdbc:postgresql:postgres",
+                                                                     :user     "postgres",
+                                                                     :password "postgres",
+                                                                     :pool     ["com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> z8kfsxa29l16ci175669f|7ffecc0b, dataSourceName -> z8kfsxa29l16ci175669f|7ffecc0b ]"]},
+   :async-supported?                      true,
+   :cookies                               {"ring-session" {:value "atvM/WXPgwbZJFydWVggM4xquCkqQLBxQvp9WPBXTzeIdoFG7NeO5BdRZzRCYuG18+RY5fVCAi/m6gR9M4OiVQ==--OXNR3CzxROHyxNwikcFZ9kdQhixVTiuX5JKZKE1PHgI="}},
+   :remote-addr                           "0:0:0:0:0:0:0:1",
+   :flash                                 nil,
+   :servlet-response                      ["HTTP/1.1 200 \nDate: Tue, 16 Apr 2019 20:58:35 GMT\r\n\r\n"],
+   :servlet                               [ "io.pedestal.http.servlet.FnServlet@6a723e70"],
+   :headers                               {"origin" "", "host" "localhost:8080", "user-agent" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36", "cookie" "ring-session=atvM%2FWXPgwbZJFydWVggM4xquCkqQLBxQvp9WPBXTzeIdoFG7NeO5BdRZzRCYuG18%2BRY5fVCAi%2Fm6gR9M4OiVQ%3D%3D--OXNR3CzxROHyxNwikcFZ9kdQhixVTiuX5JKZKE1PHgI%3D", "connection" "keep-alive", "upgrade-insecure-requests" "1", "accept" "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8", "accept-language" "en-GB,en-US;q=0.9,en;q=0.8", "accept-encoding" "gzip, deflate, br"},
+   :server-port                           8080,
+   :servlet-request                       ["Request(GET //localhost:8080/test)@7173b60b"],
+   :session/key                           "atvM/WXPgwbZJFydWVggM4xquCkqQLBxQvp9WPBXTzeIdoFG7NeO5BdRZzRCYuG18+RY5fVCAi/m6gR9M4OiVQ==--OXNR3CzxROHyxNwikcFZ9kdQhixVTiuX5JKZKE1PHgI=",
+   :path-info                             "/test",
+   :url-for                               [{:status :pending, :val nil}],
+   :uri                                   "/test",
+   :server-name                           "localhost",
+   :query-string                          nil,
+   :path-params                           {},
+   :body                                  ["HttpInputOverHTTP@304ebc30[c=0,q=0,[0]=null,s=STREAM]"],
+   :com.grzm.component.pedestal/component {:db {:url      "jdbc:postgresql:postgres",
+                                                                          :user     "postgres",
+                                                                          :password "postgres",
+                                                                          :pool     ["com.mchange.v2.c3p0.ComboPooledDataSource[ identityToken -> z8kfsxa29l16ci175669f|7ffecc0b, dataSourceName -> z8kfsxa29l16ci175669f|7ffecc0b ]"]}},
+   :scheme                                :http,
+   :request-method                        :get,
+   :session                               {:identity {:username "adam", :role "user"}}})
+
+
+(= (:headers no-login-request)
+   (:headers login-request))


### PR DESCRIPTION
## Goal
Authorize update of entries by `:authored`
So that some routes are permitted to author and admin only.
## Proposed changes
- `ALTER TABLE users ADD COLUMN authored VARCHAR(20);`
- Extend authorization depending on ownership (authorship) 
- add username to users table from `(get-in  request [session :identity :username])`
## PR status, roadblocks, etc
 
 
 
